### PR TITLE
Consolidate MAC to ENI mapping

### DIFF
--- a/sirius-pipeline/bmv2/sirius_inbound.p4
+++ b/sirius-pipeline/bmv2/sirius_inbound.p4
@@ -11,20 +11,6 @@ control inbound(inout headers_t hdr,
                 inout metadata_t meta,
                 inout standard_metadata_t standard_metadata)
 {
-    action set_eni(bit<16> eni) {
-        meta.eni = eni;
-    }
-
-    table eni_lookup_to_vm {
-        key = {
-            hdr.ethernet.dst_addr : exact @name("hdr.ethernet.dst_addr:dmac");
-        }
-
-        actions = {
-            set_eni;
-        }
-    }
-
     action set_vm_attributes(EthernetAddress underlay_dmac,
                              IPv4Address underlay_dip,
                              bit<24> vni) {
@@ -58,8 +44,6 @@ control inbound(inout headers_t hdr,
     }
 
     apply {
-        eni_lookup_to_vm.apply();
-
         eni_to_vm.apply();
 
         vm.apply();

--- a/sirius-pipeline/bmv2/sirius_metadata.p4
+++ b/sirius-pipeline/bmv2/sirius_metadata.p4
@@ -28,6 +28,7 @@ struct metadata_t {
     bool dropped;
     direction_t direction;
     encap_data_t encap_data;
+    EthernetAddress eni_addr;
     bit<16> eni;
     bit<16> vm_id;
     bit<8> appliance_id;

--- a/sirius-pipeline/bmv2/sirius_outbound.p4
+++ b/sirius-pipeline/bmv2/sirius_outbound.p4
@@ -9,20 +9,6 @@ control outbound(inout headers_t hdr,
                  inout metadata_t meta,
                  inout standard_metadata_t standard_metadata)
 {
-    action set_eni(bit<16> eni) {
-        meta.eni = eni;
-    }
-
-    table eni_lookup_from_vm {
-        key = {
-            hdr.ethernet.src_addr : exact @name("hdr.ethernet.src_addr:smac");
-        }
-
-        actions = {
-            set_eni;
-        }
-    }
-
     action set_vni(bit<24> vni) {
         meta.encap_data.vni = vni;
     }
@@ -87,8 +73,6 @@ control outbound(inout headers_t hdr,
     }
 
     apply {
-        eni_lookup_from_vm.apply();
-
         eni_to_vni.apply();
 
 #ifdef STATEFUL_P4


### PR DESCRIPTION
Make ENI mapping from inner MAC direction agnostic
by copying the right MAC to metadata before the
lookup.

Note: This does not change the behavior of the
pipeline, but simplifies the API generated based
on it.

Signed-off-by: Marian Pritsak <marianp@mellanox.com>