### PR TITLE
Remove docker daemon from memory footprint.

### DIFF
--- a/documentation/general/design/dash-sonic-hld.md
+++ b/documentation/general/design/dash-sonic-hld.md
@@ -454,7 +454,6 @@ DASH Appliance shall establish BGP session with the connected ToR and advertise 
 | Running components | Memory usage |
 |--|--|
 |Base Debian OS  | 159MB |
-|Base Debian OS + docker daemon  | 202MB |
 |Base Debian OS + docker containers | 1.3GB |
 
 #### 3.3.5.2 SONiC docker containers memory usage


### PR DESCRIPTION
Docker daemon memory usage was measured without running containers.
It might be confusing because it doesn't reflect real docker daemon
memory usage when all containers are running. Memory used by the Docker
daemon can be calculated by the following:
"all used memory" - "memory used by all docker containers" - "base OS memory".