### PR TITLE
Dash Routing: Direct, Vnet_direct and Drop action support

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -97,7 +97,7 @@ def get_sai_key_data(key):
     sai_key_data['sai_key_name'] = sai_key_name
 
     key_size = key[BITWIDTH_TAG]
-    
+
     if OTHER_MATCH_TYPE_TAG in key:
         sai_key_data['match_type'] =  key[OTHER_MATCH_TYPE_TAG].lower()
     elif MATCH_TYPE_TAG in key:
@@ -145,6 +145,15 @@ def table_with_counters(program, table_id):
             return 'true'
     return 'false'
 
+def remove_dupl_action_params(action_params, in_action):
+    out_action = in_action
+    params = []
+    for param in in_action[PARAMS_TAG]:
+        if param[NAME_TAG] not in action_params:
+            action_params.append(param[NAME_TAG])
+            params.append(param)
+    out_action[PARAMS_TAG] = params
+    return out_action
 
 def generate_sai_apis(program, ignore_tables):
     sai_apis = []
@@ -189,10 +198,14 @@ def generate_sai_apis(program, ignore_tables):
                 continue
             sai_table_data['keys'].append(get_sai_key_data(key))
 
+        action_params = []
         for action in table[ACTION_REFS_TAG]:
             action_id = action["id"]
             if all_actions[action_id][NAME_TAG] != NOACTION:
-                sai_table_data[ACTIONS_TAG].append(all_actions[action_id])
+                # ensure that same parameter passed to multiple actions for the same table
+                # does not generate more than 1 SAI attribute
+                action = remove_dupl_action_params(action_params, all_actions[action_id])
+                sai_table_data[ACTIONS_TAG].append(action)
 
         if len(sai_table_data['keys']) == 1 and sai_table_data['keys'][0]['sai_key_name'].endswith(table_name.split('.')[-1] + '_id'):
             sai_table_data['is_object'] = 'true'

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -103,8 +103,7 @@ sai_status_t sai_create_{{ table.name }}(
 
     for (uint32_t i = 0; i < attr_count; i++) {
         switch(attr_list[i].id) {
-            {% for action in table.actions %}
-            {% for param in action.params %}
+            {% for param in table.actionParams %}
             case SAI_{{ table.name | upper }}_ATTR_{{ param.name | upper }}: {
                 auto param = action->add_params();
                 param->set_param_id({{param.id}});
@@ -112,7 +111,6 @@ sai_status_t sai_create_{{ table.name }}(
                 matchedParams++;
                 break;
             }
-            {% endfor %}
             {% endfor %}
         }
     }
@@ -222,8 +220,7 @@ sai_status_t sai_create_{{ table.name }}(
 
     for (uint32_t i = 0; i < attr_count; i++) {
         switch(attr_list[i].id) {
-            {% for action in table.actions %}
-            {% for param in action.params %}
+            {% for param in table.actionParams %}
             case SAI_{{ table.name | upper }}_ATTR_{{ param.name | upper }}: {
                 auto param = action->add_params();
                 param->set_param_id({{param.id}});
@@ -231,7 +228,6 @@ sai_status_t sai_create_{{ table.name }}(
                 matchedParams++;
                 break;
             }
-            {% endfor %}
             {% endfor %}
         }
     }

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -151,18 +151,14 @@ typedef enum _sai_{{ table.name }}_attr_t
 
 {% endfor %}
 {% endif %}
-{% for action in table.actions %}
-{% for param in action.params %}
+{% for param in table.actionParams %}
     /**
-     * @brief Action {{ action.name }} parameter {{ param.name | upper }}
+     * @brief Action {% for action in param.paramActions %}{{ action }}{{ ", " if not loop.last else "" }}{% endfor %} parameter {{ param.name | upper }}
      *
      * @type {{ param.type }}
      * @flags CREATE_AND_SET
 {% if param.type == 'sai_uint16_t' %}
      * @isvlan false
-{% endif %}
-{% if table.actions | length > 1 %}
-     * @condition SAI_{{ table.name | upper }}_ATTR_ACTION == SAI_{{ table.name | upper }}_ACTION_{{ action.name | upper }}
 {% endif %}
 {% if param.type == 'sai_ip_address_t' %}
      * @default 0.0.0.0
@@ -177,6 +173,12 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% else %}
      * @default 0
 {% endif %}
+{% if table.actions | length > 1 %}
+{% if param.paramActions | length > 0 %}
+     * @validonly {% for action in param.paramActions %}SAI_{{ table.name | upper }}_ATTR_ACTION == SAI_{{ table.name | upper }}_ACTION_{{ action | upper }}{{ " or " if not loop.last else "" }}{% endfor %}
+
+{% endif %}
+{% endif %}
      */
 {% if not ns.firstattr %}
     SAI_{{ table.name | upper }}_ATTR_{{ param.name | upper }} = SAI_{{ table.name | upper }}_ATTR_START,
@@ -185,7 +187,6 @@ typedef enum _sai_{{ table.name }}_attr_t
     SAI_{{ table.name | upper }}_ATTR_{{ param.name | upper }},
 {% endif %}
 
-{% endfor %}
 {% endfor %}
 {% if table.stages | length > 0 %}
     /**

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -41,7 +41,9 @@ struct metadata_t {
     bit<16> inbound_vm_id;
     bit<8> appliance_id;
     bit<1> is_dst_ip_v6;
+    bit<1> is_lkup_dst_ip_v6;
     IPv4ORv6Address dst_ip_addr;
+    IPv4ORv6Address lkup_dst_ip_addr;
     conntrack_data_t conntrack_data;
 }
 

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -28,6 +28,22 @@ control outbound(inout headers_t hdr,
         meta.encap_data.dest_vnet_vni = dest_vnet_vni;
     }
 
+    action route_vnet_direct(bit<24> dest_vnet_vni,
+                             bit<1> is_overlay_nh_ip_v6,
+                             IPv4ORv6Address overlay_nh_ip) {
+        meta.encap_data.dest_vnet_vni = dest_vnet_vni;
+        meta.lkup_dst_ip_addr = overlay_nh_ip;
+        meta.is_lkup_dst_ip_v6 = is_overlay_nh_ip_v6;
+    }
+
+    action route_direct() {
+        /* send to underlay router without any encap */
+    }
+
+    action drop() {
+        meta.dropped = true;
+    }
+
     direct_counter(CounterType.packets_and_bytes) routing_counter;
 
     @name("routing|dash_vnet")
@@ -40,7 +56,11 @@ control outbound(inout headers_t hdr,
 
         actions = {
             route_vnet; /* for expressroute - ecmp of overlay */
+            route_vnet_direct;
+            route_direct;
+            drop;
         }
+        const default_action = drop;
 
         counters = routing_counter;
     }
@@ -66,8 +86,8 @@ control outbound(inout headers_t hdr,
         key = {
             /* Flow for express route */
             meta.encap_data.dest_vnet_vni : exact @name("meta.encap_data.dest_vnet_vni:dest_vni");
-            meta.is_dst_ip_v6 : exact @name("meta.is_dst_ip_v6:v4_or_v6");
-            meta.dst_ip_addr : exact @name("meta.dst_ip_addr:dip");
+            meta.is_lkup_dst_ip_v6 : exact @name("meta.is_lkup_dst_ip_v6:v4_or_v6");
+            meta.lkup_dst_ip_addr : exact @name("meta.lkup_dst_ip_addr:dip");
         }
 
         actions = {
@@ -100,6 +120,9 @@ control outbound(inout headers_t hdr,
 #ifdef PNA_CONNTRACK
         ConntrackIn.apply(hdr, meta);
 #endif // PNA_CONNTRACK
+
+        meta.lkup_dst_ip_addr = meta.dst_ip_addr;
+        meta.is_lkup_dst_ip_v6 = meta.is_dst_ip_v6;
 
         switch (routing.apply().action_run) {
             route_vnet: {

--- a/dash-pipeline/bmv2/dash_outbound.p4
+++ b/dash-pipeline/bmv2/dash_outbound.p4
@@ -29,11 +29,11 @@ control outbound(inout headers_t hdr,
     }
 
     action route_vnet_direct(bit<24> dest_vnet_vni,
-                             bit<1> is_overlay_nh_ip_v6,
+                             bit<1> is_overlay_nh_ip_v4_or_v6,
                              IPv4ORv6Address overlay_nh_ip) {
         meta.encap_data.dest_vnet_vni = dest_vnet_vni;
         meta.lkup_dst_ip_addr = overlay_nh_ip;
-        meta.is_lkup_dst_ip_v6 = is_overlay_nh_ip_v6;
+        meta.is_lkup_dst_ip_v6 = is_overlay_nh_ip_v4_or_v6;
     }
 
     action route_direct() {

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -223,8 +223,12 @@ control dash_ingress(inout headers_t hdr,
 
         eni_meter.apply();
 
-        /* Send packet to port 1 by default if we reached the end of pipeline */
-        standard_metadata.egress_spec = 1;
+        if (meta.dropped) {
+            drop_action();
+        } else {
+            /* Send packet to port 1 by default if we reached the end of pipeline */
+            standard_metadata.egress_spec = 1;
+        }
     }
 }
 


### PR DESCRIPTION
Support for remaining Phase 1 routing actions as specified in the Sonic HLD / Vnet-Vnet doc.
Fixes issue #134
It generates following additional SAI attributes.

```
/**
 * @brief Attribute data for #SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION
 */
typedef enum _sai_outbound_routing_entry_action_t
{
    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET,

    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET_DIRECT,    

    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_DIRECT,

    SAI_OUTBOUND_ROUTING_ENTRY_ACTION_DROP,

} sai_outbound_routing_entry_action_t;

typedef enum _sai_outbound_routing_entry_attr_t
{
    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_START,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION = SAI_OUTBOUND_ROUTING_ENTRY_ATTR_START,

     /**
     * @brief Action route_vnet, route_vnet_direct parameter DEST_VNET_VNI
     *
     * @type sai_uint32_t
     * @flags CREATE_AND_SET
     * @condition SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET or SAI_OUTBOUND_ROUTING_ENTRY_ATTR_ACTION == SAI_OUTBOUND_ROUTING_ENTRY_ACTION_ROUTE_VNET_DIRECT
     * @default 0
     */ 
     SAI_OUTBOUND_ROUTING_ENTRY_ATTR_DEST_VNET_VNI,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_IS_OVERLAY_NH_IP_V6,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_OVERLAY_NH_IP,

    SAI_OUTBOUND_ROUTING_ENTRY_ATTR_COUNTER_ID,

}

```