### PR TITLE
Temporary workaround for container permissions issues 

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash
 
-all:p4 sai test
+all:fix-perms p4 sai test
 
 PWD := $(shell pwd)
 
@@ -20,13 +20,18 @@ DOCKER_RUN := docker run \
 	--rm \
 	$(DOCKER_FLAGS)
 
+.PHONY: fix-perms
+fix-perms:
+	@echo "### Applying Fix permissions workaround..."
+	sudo chmod -R o+rw SAI/ bmv2/ tests/
+
 SAI/SAI:
 	@echo "Initializing SAI submodule..."
 	git submodule update --init
 
 P4_ARTIFACTS=bmv2/dash_pipeline.bmv2/dash_pipeline.json bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.txt
 
-p4: bmv2/dash_pipeline.bmv2/dash_pipeline.json
+p4: fix-perms bmv2/dash_pipeline.bmv2/dash_pipeline.json
 
 .PHONY:p4-clean
 p4-clean:
@@ -48,7 +53,7 @@ $(P4_ARTIFACTS):
 	    --p4runtime-files bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.json,bmv2/dash_pipeline.bmv2/dash_pipeline_p4rt.txt
 
 .PHONY:clean
-clean: kill-switch p4-clean sai-clean test-clean network-clean undeploy-ixiac
+clean: fix-perms kill-switch p4-clean sai-clean test-clean network-clean undeploy-ixiac
 	sudo rm -rf bmv2/dash_pipeline.bmv2
 	sudo make -C tests/vnet_out clean
 
@@ -79,7 +84,7 @@ kill-switch:
 
 # TODO - create separate rules for headers, libsai.so
 .PHONY:sai
-sai: p4 | SAI/SAI 
+sai: fix-perms p4 | SAI/SAI 
 	@echo "Generate SAI library headers and implementation..."
 	$(DOCKER_RUN) \
 		--name build_sai-$(USER) \

--- a/dash-pipeline/README.md
+++ b/dash-pipeline/README.md
@@ -62,8 +62,9 @@ The workflows described here are primarily driven by a [Makefile](Makefile) and 
     - [Committing new SAI submodule version](#committing-new-sai-submodule-version)
 
 # Known Issues
-* The vnet_out test via `make run-test` needs to be run to allow `run-ixiac-test` to pass. Need to understand why this is so.
+* The vnet_out test via `make run-test` needs to be run to allow `run-ixiac-test` to pass. 
 * Prebuilt Docker image is too large , see [Desired Optimizations](#desired-optimizations).
+* Docker images have permissions and ownership issues, see https://github.com/Azure/DASH/issues/143. Use `make fix-perms` as temporary workaround.
 
 # TODOs
 ## Loose Ends
@@ -121,7 +122,7 @@ git checkout <branch>
 ## Super-quick approach for the adventurous!
 In one terminal:
 ```
-make clean all network run-switch
+make clean && make all network run-switch
 ```
 In another terminal:
 ```


### PR DESCRIPTION
Fixes https://github.com/Azure/DASH/issues/143.
Executes `chmod `as required. Permanent fix will require some Docker mods.
Note, instead of `make clean all` please use `make clean && make all` to ensure `chmod` gets called prior to both make targets.

Reviewers, please clone the dev branch and try fresh `make clean && make all network run-switch` to validate this works for other users. I've tested as another alias user and it worked, but I prefer independent testing. Thanks!