### PR TITLE
Add support for IPV4 optional headers

### DIFF
--- a/dash-pipeline/bmv2/dash_headers.p4
+++ b/dash-pipeline/bmv2/dash_headers.p4
@@ -31,6 +31,10 @@ header ipv4_t {
 
 const bit<16> IPV4_HDR_SIZE=160/8;
 
+header ipv4options_t {
+    varbit<320> options;
+}
+
 header udp_t {
     bit<16>  src_port;
     bit<16>  dst_port;
@@ -81,6 +85,7 @@ const bit<16> IPV6_HDR_SIZE=320/8;
 struct headers_t {
     ethernet_t ethernet;
     ipv4_t     ipv4;
+    ipv4options_t ipv4options;
     ipv6_t     ipv6;
     udp_t      udp;
     tcp_t      tcp;


### PR DESCRIPTION
**Summary of PR**
Right now, if you send an ipv4 packet with an optional header to the pipeline, the parser will fail because it will try to extract UDP/TCP immediately after plain ipv4 header. This PR adds support for IPv4 options in the parser/deparser.

**How it was tested?** @chrispsommers 
1. Since this changeset is only related to parser/deparser, I temporarily emptied out the dash-pipeline such that is simply sends every packet coming from port 0 out to port 1
2. Bring up the setup and send different packets with/without ipv4 options to veth0
3. Examine the logs of simple_switch to verify the functionality of parser
4. Examine the contents of packets coming out of veth2 to verify the functionality of deparser
