### PR TITLE
Update link to SAI PTF User Guide

### DIFF
--- a/test/docs/README.md
+++ b/test/docs/README.md
@@ -5,7 +5,7 @@
 | [High-Level Description (HLD) Test Specification](dash-test-HLD.md) | High-level design for the testing of devices which conform to the SONiC-DASH requirements.|  
 | [Dash Test Maturity Stages](dash-test-maturity-stages.md) | Describes a progressive approach to DASH testing.|  
 | [DASH SAI-Thrift Test Workflow](dash-test-workflow-saithrift.md) | DASH test workflow with SAI-thrift. |
-| [DASH SAI-Thrift User Guide](https://github.com/opencomputeproject/SAI/blob/088627dd90c3420daf96d294c661b4a152afb01e/ptf/SAI_PTF_user-guide.md) | DASH SAI Thrift Server User Guide to autogenerate test frame work. |
+| [SAI PTF User Guide](https://github.com/opencomputeproject/SAI/blob/master/ptf/SAI_PTF_user-guide.md) | SAI Thrift Server User Guide to autogenerate test frame work. |
 | [DASH P4 SAI-Thrift Test Workflow](dash-test-workflow-p4-saithrift.md) | Use of P4-based simulators or SW dataplanes to verify DASH behavior, using saithrift API. |
 | [Testbed](testbed/README.md) | Describes the setup and configuration of a DASH testbed.|  
 


### PR DESCRIPTION
SAI PTF User Guide was upstreamed. Changing link from dev branch to main branch.