### PR TITLE
Adding vnet table to the pipeline

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -182,7 +182,10 @@ def generate_sai_apis(program, ignore_tables):
             continue
 
         table_name, api_name = table_name.split('|')
-        sai_table_data[NAME_TAG] = table_name.replace('.' , '_')
+        if '.' in table_name:
+            sai_table_data[NAME_TAG] = table_name.split('.')[-1]
+        else:
+            sai_table_data[NAME_TAG] = table_name
         sai_table_data['id'] =  table[PREAMBLE_TAG]['id']
         sai_table_data['with_counters'] = table_with_counters(program, sai_table_data['id'])
 
@@ -380,6 +383,15 @@ for sai_api in sai_apis:
                 for table_name in all_table_names:
                     if table_ref.endswith(table_name):
                         param[OBJECT_NAME_TAG] = table_name
+    # Update object name reference for keys
+    for table in sai_api[TABLES_TAG]:
+        for key in table['keys']:
+            if 'sai_key_type' in key:
+                if key['sai_key_type'] == 'sai_object_id_t':
+                    table_ref = key['sai_key_name'][:-len("_id")]
+                    for table_name in all_table_names:
+                        if table_ref.endswith(table_name):
+                            key[OBJECT_NAME_TAG] = table_name
     # Write SAI dictionary into SAI API headers
     write_sai_files(sai_api)
     write_sai_impl_files(sai_api)

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -67,7 +67,7 @@ typedef struct _sai_{{ table.name }}_t
      * @brief {{ key.match_type | capitalize | replace('Lpm', 'LPM') }} matched key {{ key.sai_key_name }}
 {% if key.sai_key_type == 'sai_object_id_t' %}
      *
-     * @objects SAI_OBJECT_TYPE_{{ key.sai_key_name | replace('_id', '') | upper }}
+     * @objects SAI_OBJECT_TYPE_{{ key.objectName | upper }}
 {% endif %}
      */
 {% if key.match_type == 'lpm' %}

--- a/dash-pipeline/bmv2/dash_metadata.p4
+++ b/dash-pipeline/bmv2/dash_metadata.p4
@@ -36,6 +36,8 @@ struct metadata_t {
     direction_t direction;
     encap_data_t encap_data;
     EthernetAddress eni_addr;
+    bit<16> vnet_id;
+    bit<16> dst_vnet_id;
     bit<16> eni_id;
     eni_data_t eni_data;
     bit<16> inbound_vm_id;

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -102,6 +102,7 @@ control dash_ingress(inout headers_t hdr,
                          bit<1> admin_state,
                          IPv4Address vm_underlay_dip,
                          bit<24> vm_vni,
+                         bit<16> vnet_id,
                          ACL_GROUPS_PARAM(inbound_v4),
                          ACL_GROUPS_PARAM(inbound_v6),
                          ACL_GROUPS_PARAM(outbound_v4),
@@ -111,7 +112,10 @@ control dash_ingress(inout headers_t hdr,
         meta.eni_data.flows          = flows;
         meta.eni_data.admin_state    = admin_state;
         meta.encap_data.underlay_dip = vm_underlay_dip;
+        /* vm_vni is the encap VNI used for tunnel between inbound DPU -> VM
+         * and not a VNET identifier */
         meta.encap_data.vni          = vm_vni;
+        meta.vnet_id                 = vnet_id;
 
         if (meta.is_dst_ip_v6 == 1) {
             if (meta.direction == direction_t.OUTBOUND) {


### PR DESCRIPTION
- ENI table drives vnet-id for the VNET table as specified in the GNMI
schema
- Route lookup drives destination vnet-id for the VNET table lookup
- Removing redundant eni_to_vni table