### PR TITLE
Fix SAI object create error in libsai adapter

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -219,8 +219,6 @@ def generate_sai_apis(program, ignore_tables):
 
         if len(sai_table_data['keys']) == 1 and sai_table_data['keys'][0]['sai_key_name'].endswith(table_name.split('.')[-1] + '_id'):
             sai_table_data['is_object'] = 'true'
-            # Object ID itself is a key
-            sai_table_data['keys'] = []
         elif len(sai_table_data['keys']) > 5:
             sai_table_data['is_object'] = 'true'
         else:

--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -39,12 +39,23 @@ sai_status_t sai_create_{{ table.name }}(
     auto action = entry->mutable_action();
     auto expectedParams = 0;
     auto matchedParams = 0;
-
-    // Search the action 
+    sai_object_id_t objId = 0;
+    // Search the action
     pi_p4_id_t actionId;
 
     matchActionEntry->set_table_id(tableId);
 
+    {% if table['keys'] | length== 1 %}
+    // SAI object table with single P4 key - object ID itself is the P4 table key
+    // Generate a SAI object ID and fill it as the P4 table key
+    auto mf = matchActionEntry->add_match();
+    mf->set_field_id({{table['keys'][0].id}});
+    objId = NextObjIndex();
+    auto mf_exact = mf->mutable_exact();
+    {{table['keys'][0].sai_key_field}}SetVal(objId, mf_exact, {{table['keys'][0].bitwidth}});
+    {% else %}
+    // SAI object table with multiple P4 table keys
+    // Copy P4 table keys from appropriate SAI attributes
     for (uint32_t i = 0; i < attr_count; i++) {
         switch(attr_list[i].id) {
             {% for key in table['keys'] %}
@@ -74,6 +85,7 @@ sai_status_t sai_create_{{ table.name }}(
             {% endfor %}
         }
     }
+    {% endif %}
 
 
     // If there is only one action, simply set it.
@@ -121,7 +133,6 @@ sai_status_t sai_create_{{ table.name }}(
         goto ErrRet;
     }
     // TODO: ternaly needs to set priority
-    uint64_t objId;
     if (true == InsertInTable(matchActionEntry, &objId)) {
         *{{ table.name }}_id = objId;
         return 0;

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -110,6 +110,7 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% set ns.firstattr = true %}
 {% endif %}
 {% if table.is_object == 'true' %}
+{% if table['keys'] | length > 1 %}
 {% for key in table['keys'] %}
     /**
      * @brief {{ key.match_type | capitalize | replace('Lpm', 'LPM') }} matched key {{ key.sai_key_name }}
@@ -139,6 +140,7 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% endif %}
 
 {% endfor %}
+{% endif %}
 {% endif %}
 {% for param in table.actionParams %}
     /**

--- a/dash-pipeline/SAI/templates/utils.cpp.j2
+++ b/dash-pipeline/SAI/templates/utils.cpp.j2
@@ -168,10 +168,16 @@ bool InsertInTable(p4::v1::TableEntry *entry, sai_object_id_t *objId) {
     }
 
     tableLock.lock();
-    *objId = nextId++;
+    if (*objId == 0) {
+        *objId = nextId++;
+    }
     tableEntryMap[*objId] = entry;
     tableLock.unlock();
     return true;
+}
+
+sai_object_id_t NextObjIndex() {
+    return ++nextId;
 }
 
 bool RemoveFromTable(sai_object_id_t id) {
@@ -258,6 +264,10 @@ sai_status_t sai_api_query(
             *api_method_table = (void *)&sai_dash_api_impl;
             break;
         
+        case SAI_API_DASH_ACL:
+            *api_method_table = (void *)&sai_dash_acl_api_impl;
+            break;
+
         case SAI_API_DASH_VNET:
             *api_method_table = (void *)&sai_dash_vnet_api_impl;
             break;

--- a/dash-pipeline/SAI/templates/utils.h.j2
+++ b/dash-pipeline/SAI/templates/utils.h.j2
@@ -220,6 +220,8 @@ void ipaddrrangelistSetVal(const sai_attribute_value_t &value, T &t, int bits = 
 
 grpc::StatusCode MutateTableEntry(p4::v1::TableEntry *entry, p4::v1::Update_Type updateType);
 
+sai_object_id_t NextObjIndex();
+
 bool InsertInTable(p4::v1::TableEntry *entry, sai_object_id_t *objId);
 
 bool RemoveFromTable(sai_object_id_t id);

--- a/dash-pipeline/tests/libsai/vnet_out/vnet_out.cpp
+++ b/dash-pipeline/tests/libsai/vnet_out/vnet_out.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <vector>
+#include <unordered_map>
 #include <string.h>
 
 #include <sai.h>
@@ -26,6 +27,22 @@ extern sai_status_t sai_create_outbound_eni_to_vni_entry(
 extern sai_status_t sai_remove_outbound_eni_to_vni_entry(
         _In_ const sai_outbound_eni_to_vni_entry_t *outbound_eni_to_vni_entry);
 
+extern sai_status_t sai_create_eni(
+        _Out_ sai_object_id_t *eni_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+extern sai_status_t sai_remove_eni(
+        _In_ sai_object_id_t eni_id);
+
+extern sai_status_t sai_create_dash_acl_group(
+        _Out_ sai_object_id_t *acl_group_id,
+        _In_ sai_object_id_t switch_id,
+        _In_ uint32_t attr_count,
+        _In_ const sai_attribute_t *attr_list);
+extern sai_status_t sai_remove_dash_acl_group(
+        _In_ sai_object_id_t eni_id);
+
 extern sai_dash_api_t sai_dash_api_impl;
 
 int main(int argc, char **argv)
@@ -33,6 +50,9 @@ int main(int argc, char **argv)
     sai_object_id_t switch_id = SAI_NULL_OBJECT_ID;
     sai_attribute_t attr;
     std::vector<sai_attribute_t> attrs;
+    sai_object_id_t in_acl_group_id;
+    sai_object_id_t out_acl_group_id;
+    sai_object_id_t eni_id;
 
     sai_direction_lookup_entry_t dle = {};
     dle.switch_id = switch_id;
@@ -52,6 +72,91 @@ int main(int argc, char **argv)
 
     attrs.clear();
 
+    attr.id = SAI_DASH_ACL_GROUP_ATTR_IP_ADDR_FAMILY;
+    attr.value.s32 = SAI_IP_ADDR_FAMILY_IPV4;
+    attrs.push_back(attr);
+
+    /* status = sai_dash_api_impl.create_dash_acl_group(&group_id, switch_id, attrs.size(), attrs.data()); */
+    status = sai_create_dash_acl_group(&in_acl_group_id, switch_id, attrs.size(), attrs.data());
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        std::cout << "Failed to create inbound Dash ACL group" << std::endl;
+        return 1;
+    }
+    status = sai_create_dash_acl_group(&out_acl_group_id, switch_id, attrs.size(), attrs.data());
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        std::cout << "Failed to create outbound Dash ACL group" << std::endl;
+        return 1;
+    }
+
+    attrs.clear();
+
+    attr.id = SAI_ENI_ATTR_CPS;
+    attr.value.u32 = 10000;
+    attrs.push_back(attr);
+
+    attr.id = SAI_ENI_ATTR_PPS;
+    attr.value.u32 = 100000;
+    attrs.push_back(attr);
+
+    attr.id = SAI_ENI_ATTR_FLOWS;
+    attr.value.u32 = 100000;
+    attrs.push_back(attr);
+
+    attr.id = SAI_ENI_ATTR_ADMIN_STATE;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
+    attr.id = SAI_ENI_ATTR_VM_UNDERLAY_DIP;
+    sai_ip_addr_t u_dip_addr = {.ip4 = 0x010310ac};
+    sai_ip_address_t u_dip = {.addr_family = SAI_IP_ADDR_FAMILY_IPV4,
+                              .addr = u_dip_addr};
+    attr.value.ipaddr = u_dip;
+    attrs.push_back(attr);
+
+    attr.id = SAI_ENI_ATTR_VM_VNI;
+    attr.value.u32 = 9;
+    attrs.push_back(attr);
+
+    std::unordered_map<uint32_t, uint16_t> acl_group_ids = {
+      {SAI_ENI_ATTR_INBOUND_V4_STAGE1_DASH_ACL_GROUP_ID, in_acl_group_id},
+      {SAI_ENI_ATTR_INBOUND_V4_STAGE2_DASH_ACL_GROUP_ID, in_acl_group_id},
+      {SAI_ENI_ATTR_INBOUND_V4_STAGE3_DASH_ACL_GROUP_ID, in_acl_group_id},
+      {SAI_ENI_ATTR_INBOUND_V4_STAGE4_DASH_ACL_GROUP_ID, in_acl_group_id},
+      {SAI_ENI_ATTR_INBOUND_V4_STAGE5_DASH_ACL_GROUP_ID, in_acl_group_id},
+      {SAI_ENI_ATTR_OUTBOUND_V4_STAGE1_DASH_ACL_GROUP_ID, out_acl_group_id},
+      {SAI_ENI_ATTR_OUTBOUND_V4_STAGE2_DASH_ACL_GROUP_ID, out_acl_group_id},
+      {SAI_ENI_ATTR_OUTBOUND_V4_STAGE3_DASH_ACL_GROUP_ID, out_acl_group_id},
+      {SAI_ENI_ATTR_OUTBOUND_V4_STAGE4_DASH_ACL_GROUP_ID, out_acl_group_id},
+      {SAI_ENI_ATTR_OUTBOUND_V4_STAGE5_DASH_ACL_GROUP_ID, out_acl_group_id},
+      {SAI_ENI_ATTR_INBOUND_V6_STAGE1_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_INBOUND_V6_STAGE2_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_INBOUND_V6_STAGE3_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_INBOUND_V6_STAGE4_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_INBOUND_V6_STAGE5_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_OUTBOUND_V6_STAGE1_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_OUTBOUND_V6_STAGE2_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_OUTBOUND_V6_STAGE3_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_OUTBOUND_V6_STAGE4_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+      {SAI_ENI_ATTR_OUTBOUND_V6_STAGE5_DASH_ACL_GROUP_ID, SAI_NULL_OBJECT_ID},
+    };
+    for (const auto& acl_grp_pair : acl_group_ids) {
+        attr.id = acl_grp_pair.first;
+        attr.value.oid = acl_grp_pair.second;
+        attrs.push_back(attr);
+    }
+
+    /* status = sai_dash_api_impl.create_eni(&eni_id, switch_id, attrs.size(), attrs.data()); */
+    status = sai_create_eni(&eni_id, switch_id, attrs.size(), attrs.data());
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        std::cout << "Failed to create ENI object" << std::endl;
+        return 1;
+    }
+
+    attrs.clear();
+
     sai_eni_ether_address_map_entry_t eam;
     eam.switch_id = switch_id;
     eam.address[0] = 0xaa;
@@ -62,7 +167,7 @@ int main(int argc, char **argv)
     eam.address[5] = 0xcc;
 
     attr.id = SAI_ENI_ETHER_ADDRESS_MAP_ENTRY_ATTR_ENI_ID;
-    attr.value.u16 = 7;
+    attr.value.u16 = eni_id;
     attrs.push_back(attr);
 
     status = sai_create_eni_ether_address_map_entry(&eam, attrs.size(), attrs.data());
@@ -76,7 +181,7 @@ int main(int argc, char **argv)
 
     sai_outbound_eni_to_vni_entry_t e2v = {};
     e2v.switch_id = switch_id;
-    e2v.eni_id = 7;
+    e2v.eni_id = eni_id;
 
     attr.id = SAI_OUTBOUND_ENI_TO_VNI_ENTRY_ATTR_VNI;
     attr.value.u32 = 9;
@@ -106,13 +211,35 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    status = sai_remove_eni(eni_id);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        std::cout << "Failed to remove ENI object " << eni_id << std::endl;
+        return 1;
+    }
+
+    status = sai_remove_dash_acl_group(out_acl_group_id);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        std::cout << "Failed to remove Outbound ACL group object "
+                  << out_acl_group_id << std::endl;
+        return 1;
+    }
+
+    status = sai_remove_dash_acl_group(in_acl_group_id);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        std::cout << "Failed to remove Inbound ACL group object "
+                  << in_acl_group_id << std::endl;
+        return 1;
+    }
+
     status = sai_remove_direction_lookup_entry(&dle);
     if (status != SAI_STATUS_SUCCESS)
     {
         std::cout << "Failed to remove Direction Lookup Entry" << std::endl;
         return 1;
     }
-
 
     std::cout << "Done." << std::endl;
 

--- a/dash-pipeline/tests/saithrift/ptf/vnet/test_saithrift_vnet.py
+++ b/dash-pipeline/tests/saithrift/ptf/vnet/test_saithrift_vnet.py
@@ -7,29 +7,64 @@ from sai_base_test import *
 # TODO - when switch APIs implemented:
 # class TestSaiThrift_create_outbound_eni_to_vni_entry(SaiHelper):
 
-class TestSaiThrift_create_outbound_eni_to_vni_entry(ThriftInterfaceDataPlane):
+class TestSaiThrift_create_eni(ThriftInterfaceDataPlane):
     """ Test saithrift vnet outbound"""
     def setUp(self):
-        super(TestSaiThrift_create_outbound_eni_to_vni_entry, self).setUp()
+        super(TestSaiThrift_create_eni, self).setUp()
         self.switch_id = 0
         self.eth_addr = '\xaa\xcc\xcc\xcc\xcc\xcc'
         self.vni = 60
         self.eni = 7
-        self.dle = sai_thrift_direction_lookup_entry_t(switch_id=self.switch_id, vni=self.vni)
-        self.eam = sai_thrift_eni_ether_address_map_entry_t(switch_id=self.switch_id, address = self.eth_addr)
-        self.e2v = sai_thrift_outbound_eni_to_vni_entry_t(switch_id=self.switch_id, eni_id=self.eni)
 
         try:
-
+            self.dle = sai_thrift_direction_lookup_entry_t(switch_id=self.switch_id, vni=self.vni)
+            
             status = sai_thrift_create_direction_lookup_entry(self.client, self.dle,
                                 action=SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION)
             assert(status == SAI_STATUS_SUCCESS)
-            
+
+            self.in_acl_group_id = sai_thrift_create_dash_acl_group(self.client,
+                                                                    ip_addr_family=SAI_IP_ADDR_FAMILY_IPV4)
+            assert (self.in_acl_group_id != SAI_NULL_OBJECT_ID)
+            self.out_acl_group_id = sai_thrift_create_dash_acl_group(self.client,
+                                                                     ip_addr_family=SAI_IP_ADDR_FAMILY_IPV4)
+            assert (self.in_acl_group_id != SAI_NULL_OBJECT_ID)
+
+            vm_underlay_dip = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
+                                                      addr=sai_thrift_ip_addr_t(ip4="172.16.3.1"))
+            self.eni = sai_thrift_create_eni(self.client, cps=10000,
+                                             pps=100000, flows=100000,
+                                             admin_state=True,
+                                             vm_underlay_dip=vm_underlay_dip,
+                                             vm_vni=9,
+                                             inbound_v4_stage1_dash_acl_group_id = self.in_acl_group_id,
+                                             inbound_v4_stage2_dash_acl_group_id = self.in_acl_group_id,
+                                             inbound_v4_stage3_dash_acl_group_id = self.in_acl_group_id,
+                                             inbound_v4_stage4_dash_acl_group_id = self.in_acl_group_id,
+                                             inbound_v4_stage5_dash_acl_group_id = self.in_acl_group_id,
+                                             outbound_v4_stage1_dash_acl_group_id = self.out_acl_group_id,
+                                             outbound_v4_stage2_dash_acl_group_id = self.out_acl_group_id,
+                                             outbound_v4_stage3_dash_acl_group_id = self.out_acl_group_id,
+                                             outbound_v4_stage4_dash_acl_group_id = self.out_acl_group_id,
+                                             outbound_v4_stage5_dash_acl_group_id = self.out_acl_group_id,
+                                             inbound_v6_stage1_dash_acl_group_id = 0,
+                                             inbound_v6_stage2_dash_acl_group_id = 0,
+                                             inbound_v6_stage3_dash_acl_group_id = 0,
+                                             inbound_v6_stage4_dash_acl_group_id = 0,
+                                             inbound_v6_stage5_dash_acl_group_id = 0,
+                                             outbound_v6_stage1_dash_acl_group_id = 0,
+                                             outbound_v6_stage2_dash_acl_group_id = 0,
+                                             outbound_v6_stage3_dash_acl_group_id = 0,
+                                             outbound_v6_stage4_dash_acl_group_id = 0,
+                                             outbound_v6_stage5_dash_acl_group_id = 0)
+
+            self.eam = sai_thrift_eni_ether_address_map_entry_t(switch_id=self.switch_id, address = self.eth_addr)
             status = sai_thrift_create_eni_ether_address_map_entry(self.client,
                                                         eni_ether_address_map_entry=self.eam,
                                                         eni_id=self.eni)
             assert(status == SAI_STATUS_SUCCESS)
 
+            self.e2v = sai_thrift_outbound_eni_to_vni_entry_t(switch_id=self.switch_id, eni_id=self.eni)
             status = sai_thrift_create_outbound_eni_to_vni_entry(self.client,
                                                                     outbound_eni_to_vni_entry=self.e2v,
                                                                     vni=self.vni)
@@ -38,9 +73,18 @@ class TestSaiThrift_create_outbound_eni_to_vni_entry(ThriftInterfaceDataPlane):
         except AssertionError as ae:
             # Delete entries which might be lingering from previous failures etc.; ignore failures here
             print ("Cleaning up after failure...")
-            sai_thrift_remove_outbound_eni_to_vni_entry(self.client, self.e2v)
-            sai_thrift_remove_eni_ether_address_map_entry(self.client, self.eam)
-            sai_thrift_remove_direction_lookup_entry(self.client, self.dle)
+            if hasattr(self, "e2v"):
+                sai_thrift_remove_outbound_eni_to_vni_entry(self.client, self.e2v)
+            if hasattr(self, "eam"):
+                sai_thrift_remove_eni_ether_address_map_entry(self.client, self.eam)
+            if hasattr(self, "eni"):
+                sai_thrift_remove_eni(self.client, self.eni)
+            if hasattr(self, "out_acl_group_id") and self.out_acl_group_id != SAI_NULL_OBJECT_ID:
+                sai_thrift_remove_dash_acl_group(self.client, self.out_acl_group_id)
+            if hasattr(self, "in_acl_group_id") and self.in_acl_group_id != SAI_NULL_OBJECT_ID:
+                sai_thrift_remove_dash_acl_group(self.client, self.in_acl_group_id)
+            if hasattr(self, "dle"):
+                sai_thrift_remove_direction_lookup_entry(self.client, self.dle)
             raise ae
 
 
@@ -64,8 +108,15 @@ class TestSaiThrift_create_outbound_eni_to_vni_entry(ThriftInterfaceDataPlane):
         status = sai_thrift_remove_eni_ether_address_map_entry(self.client, self.eam)
         assert(status == SAI_STATUS_SUCCESS)                        
 
+        status = sai_thrift_remove_eni(self.client, self.eni)
+        assert(status == SAI_STATUS_SUCCESS)
+
+        status = sai_thrift_remove_dash_acl_group(self.client, self.out_acl_group_id)
+        assert(status == SAI_STATUS_SUCCESS)
+
+        status = sai_thrift_remove_dash_acl_group(self.client, self.in_acl_group_id)
+        assert(status == SAI_STATUS_SUCCESS)
+
         status = sai_thrift_remove_direction_lookup_entry(self.client, self.dle)
         assert(status == SAI_STATUS_SUCCESS)                        
-
-
     

--- a/dash-pipeline/tests/saithrift/pytest/vnet/test_saithrift_vnet.py
+++ b/dash-pipeline/tests/saithrift/pytest/vnet/test_saithrift_vnet.py
@@ -10,7 +10,7 @@ from sai_thrift.ttypes  import *
 @pytest.mark.bmv2
 @pytest.mark.vnet
 
-def test_sai_thrift_create_outbound_eni_to_vni_entry(saithrift_client):
+def test_sai_thrift_create_eni(saithrift_client):
 
     switch_id = 0
     eth_addr = '\xaa\xcc\xcc\xcc\xcc\xcc'
@@ -19,13 +19,49 @@ def test_sai_thrift_create_outbound_eni_to_vni_entry(saithrift_client):
 
     try:
         dle = sai_thrift_direction_lookup_entry_t(switch_id=switch_id, vni=vni)
-        eam = sai_thrift_eni_ether_address_map_entry_t(switch_id=switch_id, address = eth_addr)
-        e2v = sai_thrift_outbound_eni_to_vni_entry_t(switch_id=switch_id, eni_id=eni)
-
         status = sai_thrift_create_direction_lookup_entry(saithrift_client, dle,
                             action=SAI_DIRECTION_LOOKUP_ENTRY_ACTION_SET_OUTBOUND_DIRECTION)
         assert(status == SAI_STATUS_SUCCESS)
         
+        in_acl_group_id = sai_thrift_create_dash_acl_group(saithrift_client,
+                                                           ip_addr_family=SAI_IP_ADDR_FAMILY_IPV4)
+        assert (in_acl_group_id != SAI_NULL_OBJECT_ID);
+        out_acl_group_id = sai_thrift_create_dash_acl_group(saithrift_client,
+                                                            ip_addr_family=SAI_IP_ADDR_FAMILY_IPV4)
+        assert (out_acl_group_id != SAI_NULL_OBJECT_ID);
+
+        vm_underlay_dip = sai_thrift_ip_address_t(addr_family=SAI_IP_ADDR_FAMILY_IPV4,
+                                                  addr=sai_thrift_ip_addr_t(ip4="172.16.3.1"))
+        eni = sai_thrift_create_eni(saithrift_client, cps=10000,
+                                    pps=100000, flows=100000,
+                                    admin_state=True,
+                                    vm_underlay_dip=vm_underlay_dip,
+                                    vm_vni=9,
+                                    inbound_v4_stage1_dash_acl_group_id = in_acl_group_id,
+                                    inbound_v4_stage2_dash_acl_group_id = in_acl_group_id,
+                                    inbound_v4_stage3_dash_acl_group_id = in_acl_group_id,
+                                    inbound_v4_stage4_dash_acl_group_id = in_acl_group_id,
+                                    inbound_v4_stage5_dash_acl_group_id = in_acl_group_id,
+                                    outbound_v4_stage1_dash_acl_group_id = out_acl_group_id,
+                                    outbound_v4_stage2_dash_acl_group_id = out_acl_group_id,
+                                    outbound_v4_stage3_dash_acl_group_id = out_acl_group_id,
+                                    outbound_v4_stage4_dash_acl_group_id = out_acl_group_id,
+                                    outbound_v4_stage5_dash_acl_group_id = out_acl_group_id,
+                                    inbound_v6_stage1_dash_acl_group_id = 0,
+                                    inbound_v6_stage2_dash_acl_group_id = 0,
+                                    inbound_v6_stage3_dash_acl_group_id = 0,
+                                    inbound_v6_stage4_dash_acl_group_id = 0,
+                                    inbound_v6_stage5_dash_acl_group_id = 0,
+                                    outbound_v6_stage1_dash_acl_group_id = 0,
+                                    outbound_v6_stage2_dash_acl_group_id = 0,
+                                    outbound_v6_stage3_dash_acl_group_id = 0,
+                                    outbound_v6_stage4_dash_acl_group_id = 0,
+                                    outbound_v6_stage5_dash_acl_group_id = 0)
+        assert (eni != SAI_NULL_OBJECT_ID);
+
+        eam = sai_thrift_eni_ether_address_map_entry_t(switch_id=switch_id, address = eth_addr)
+        e2v = sai_thrift_outbound_eni_to_vni_entry_t(switch_id=switch_id, eni_id=eni)
+
         status = sai_thrift_create_eni_ether_address_map_entry(saithrift_client,
                                                     eni_ether_address_map_entry=eam,
                                                     eni_id=eni)
@@ -58,15 +94,33 @@ def test_sai_thrift_create_outbound_eni_to_vni_entry(saithrift_client):
         status = sai_thrift_remove_eni_ether_address_map_entry(saithrift_client, eam)
         assert(status == SAI_STATUS_SUCCESS)                        
 
+        status = sai_thrift_remove_eni(saithrift_client, eni)
+        assert(status == SAI_STATUS_SUCCESS)
+
+        status = sai_thrift_remove_dash_acl_group(saithrift_client, out_acl_group_id)
+        assert(status == SAI_STATUS_SUCCESS)
+
+        status = sai_thrift_remove_dash_acl_group(saithrift_client, in_acl_group_id)
+        assert(status == SAI_STATUS_SUCCESS)
+
         status = sai_thrift_remove_direction_lookup_entry(saithrift_client, dle)
         assert(status == SAI_STATUS_SUCCESS)                        
         
     except AssertionError as ae:
         # Delete entries which might be lingering from previous failures etc.; ignore failures here
         print ("Cleaning up after failure...")
-        sai_thrift_remove_outbound_eni_to_vni_entry(saithrift_client, e2v)
-        sai_thrift_remove_eni_ether_address_map_entry(saithrift_client, eam)
-        sai_thrift_remove_direction_lookup_entry(saithrift_client, dle)
+        if "e2v" in locals():
+            sai_thrift_remove_outbound_eni_to_vni_entry(saithrift_client, e2v)
+        if "eam" in locals():
+            sai_thrift_remove_eni_ether_address_map_entry(saithrift_client, eam)
+        if "eni" in locals():
+            sai_thrift_remove_eni(saithrift_client, eni)
+        if "out_acl_group_id" in locals():
+            sai_thrift_remove_dash_acl_group(saithrift_client, out_acl_group_id)
+        if "in_acl_group_id" in locals():
+            sai_thrift_remove_dash_acl_group(saithrift_client, in_acl_group_id)
+        if "dle" in locals():
+            sai_thrift_remove_direction_lookup_entry(saithrift_client, dle)
         raise ae
 
     print ("test_sai_thrift_create_outbound_eni_to_vni_entry OK")


### PR DESCRIPTION
Populate SAI obj-id as P4 match key.
No change in SAI API headers.

Fixes #166 

```
docker exec -w /tests/libsai/vnet_out simple_switch-mukesh ./vnet_out
GRPC call SetForwardingPipelineConfig 0.0.0.0:9559 => /etc/dash/dash_pipeline.json, /etc/dash/dash_pipeline_p4rt.txt
GRPC call Write::INSERT OK
GRPC call Write::INSERT OK
GRPC call Write::INSERT OK
GRPC call Write::INSERT OK
GRPC call Write::INSERT OK
GRPC call Write::INSERT OK
GRPC call Write::DELETE OK
GRPC call Write::DELETE OK
GRPC call Write::DELETE OK
GRPC call Write::DELETE OK
GRPC call Write::DELETE OK
GRPC call Write::DELETE OK
Done.
```

```
Match key:
* hdr.vxlan.vni:VNI   : EXACT     3c0000
Action entry: dash_ingress.set_outbound_direction -

[01:04:43.937] [bmv2] [D] [thread 40] Entry 0 added to table 'dash_ingress.dash_acl_group|dash_acl'
[01:04:43.937] [bmv2] [D] [thread 40] Dumping entry 0
Match key:
* meta.stage1_dash_acl_group_id:dash_acl_group_id: EXACT     0001
Action entry: dash_ingress.set_acl_group_attrs - 0,

[01:04:43.938] [bmv2] [D] [thread 16] Entry 1 added to table 'dash_ingress.dash_acl_group|dash_acl'
[01:04:43.938] [bmv2] [D] [thread 16] Dumping entry 1
Match key:
* meta.stage1_dash_acl_group_id:dash_acl_group_id: EXACT     0002
Action entry: dash_ingress.set_acl_group_attrs - 0,

[01:04:43.939] [bmv2] [D] [thread 40] Entry 0 added to table 'dash_ingress.eni|dash'
[01:04:43.939] [bmv2] [D] [thread 40] Dumping entry 0
Match key:
* meta.eni_id:eni_id  : EXACT     0003
Action entry: dash_ingress.set_eni_attrs - 27100000,86a00000,86a00000,1,10310ac,90000,1,1,1,1,1,0,0,0,0,0,2,2,2,2,2,0,0,0,0,0,

[01:04:43.939] [bmv2] [D] [thread 16] Entry 0 added to table 'dash_ingress.eni_ether_address_map|dash'
[01:04:43.939] [bmv2] [D] [thread 16] Dumping entry 0
Match key:
* meta.eni_addr:address: EXACT     aacccccccccc
Action entry: dash_ingress.set_eni - 3,

[01:04:43.940] [bmv2] [D] [thread 40] Entry 0 added to table 'dash_ingress.outbound.eni_to_vni|dash_vnet'
[01:04:43.940] [bmv2] [D] [thread 40] Dumping entry 0
Match key:
* meta.eni_id:eni_id  : EXACT     0003
Action entry: dash_ingress.outbound.set_vni - 90000,

[01:04:43.940] [bmv2] [D] [thread 16] Removed entry 0 from table 'dash_ingress.outbound.eni_to_vni|dash_vnet'
[01:04:43.941] [bmv2] [D] [thread 40] Removed entry 0 from table 'dash_ingress.eni_ether_address_map|dash'
[01:04:43.941] [bmv2] [D] [thread 16] Removed entry 0 from table 'dash_ingress.eni|dash'
[01:04:43.941] [bmv2] [D] [thread 40] Removed entry 1 from table 'dash_ingress.dash_acl_group|dash_acl'
[01:04:43.942] [bmv2] [D] [thread 16] Removed entry 0 from table 'dash_ingress.dash_acl_group|dash_acl'
[01:04:43.942] [bmv2] [D] [thread 40] Removed entry 0 from table 'dash_ingress.direction_lookup|dash'


```