### PR TITLE
Fix inbound VNET routing classification

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -109,7 +109,7 @@ def get_sai_key_data(key):
     else:
         raise ValueError(f'No valid match tag found')
 
-    if sai_key_data['match_type'] == 'exact' or  sai_key_data['match_type'] == 'optional':
+    if sai_key_data['match_type'] == 'exact' or  sai_key_data['match_type'] == 'optional' or sai_key_data['match_type'] == 'ternary':
         sai_key_data['sai_key_type'], sai_key_data['sai_key_field'] = get_sai_key_type(key_size, key_header, key_field)
     elif sai_key_data['match_type'] == 'lpm':
         sai_key_data['sai_lpm_type'], sai_key_data['sai_lpm_field'] = get_sai_lpm_type(key_size, key_header, key_field)

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -82,7 +82,23 @@ typedef struct _sai_{{ table.name }}_t
     {{ key.sai_key_type }} {{ key.sai_key_name | lower }};
 {% endif %}
 
+{% if key.match_type == 'ternary' %}
+    /**
+     * @brief Ternary key {{ key.sai_key_name }} mask
+     */
+    {{ key.sai_key_type }} {{ key.sai_key_name | lower }}_mask;
+
+{% endif %}
 {% endfor %}
+{% if table['keys'] | selectattr('match_type', 'ne', 'exact') | list | length > 0 %}
+{% if table['keys'] | selectattr('match_type', 'eq', 'lpm') | list | length == 0 %}
+    /**
+     * @brief Rule priority in table
+     */
+    sai_uint32_t priority;
+
+{% endif %}
+{% endif %}
 } sai_{{ table.name }}_t;
 
 {% endif %}
@@ -196,6 +212,7 @@ typedef enum _sai_{{ table.name }}_attr_t
     SAI_{{ table.name | upper }}_ATTR_COUNTER_ID,
 
 {% endif %}
+{% if table.is_object == 'true' %}
 {% if table['keys'] | selectattr('match_type', 'ne', 'exact') | list | length > 0 %}
 {% if table['keys'] | selectattr('match_type', 'eq', 'lpm') | list | length == 0 %}
     /**
@@ -206,6 +223,7 @@ typedef enum _sai_{{ table.name }}_attr_t
      */
     SAI_{{ table.name | upper }}_ATTR_PRIORITY,
 
+{% endif %}
 {% endif %}
 {% endif %}
     /**

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -161,14 +161,15 @@ control dash_ingress(inout headers_t hdr,
         meta.dropped = false;
     }
 
-    action vxlan_decap_pa_validate() {}
+    action vxlan_decap_pa_validate(bit<16> src_vnet_id) {
+        meta.vnet_id = src_vnet_id;
+    }
 
     @name("pa_validation|dash_vnet")
     table pa_validation {
         key = {
-            meta.eni_id: exact @name("meta.eni_id:eni_id");
+            meta.vnet_id: exact @name("meta.vnet_id:vnet_id");
             hdr.ipv4.src_addr : exact @name("hdr.ipv4.src_addr:sip");
-            hdr.vxlan.vni : exact @name("hdr.vxlan.vni:VNI");
         }
 
         actions = {
@@ -182,7 +183,9 @@ control dash_ingress(inout headers_t hdr,
     @name("inbound_routing|dash_vnet")
     table inbound_routing {
         key = {
+            meta.eni_id: exact @name("meta.eni_id:eni_id");
             hdr.vxlan.vni : exact @name("hdr.vxlan.vni:VNI");
+            hdr.ipv4.src_addr : ternary @name("hdr.ipv4.src_addr:sip");
         }
         actions = {
             vxlan_decap(hdr);


### PR DESCRIPTION
Classify inbound packet to VNET instead of using VNI
as VNIs alone may overlap

Signed-off-by: Marian Pritsak <marianp@mellanox.com>