### PR TITLE
CI: Use repo/branch with SAI PTF DASH support

### DIFF
--- a/.github/workflows/dash-bmv2-ci.yml
+++ b/.github/workflows/dash-bmv2-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ "**" ]
     paths:
+      - '.gitmodules'
       - '.github/workflows/dash-bmv2-ci.yml'
       - 'test/**.py'
       - 'test/**requirements.txt'
@@ -19,6 +20,7 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
+      - '.gitmodules'
       - '.github/workflows/dash-bmv2-ci.yml'
       - 'test/**.py'
       - 'test/**requirements.txt'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "SAI"]
 	path = dash-pipeline/SAI/SAI
-	url = https://github.com/opencomputeproject/SAI.git
-	branch = master
+	url = https://github.com/reshmaintel/SAI.git
+	branch = dash-ptf-ci


### PR DESCRIPTION
At this moment, all changes required to run SAI PTF Thrift tests on devices with fewer ports (like DASH devices) are done in dev repos. Meanwhile the changes are upstreaming into main SAI/PTF repos, changing CI to use this development repo to be able to run PTF tests now. Once all PTF/SAI Thrift changes are merged, this submodule needs to be changed back to use mainstream SAI repo.

Signed-off-by: Volodymyr Mytnyk <volodymyrx.mytnyk@intel.com>