### PR TITLE
SAI apigen support for tables with no action parameters and a single action

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -34,7 +34,7 @@
  */
 
 {% for table in sai_api.tables %}
-{% if table.actions | length > 1 %}
+{% if table.actions | length > 1 or ((table.actions | length == 1) and (((table.is_object == 'false') or (table['keys'] | length <= 1)) and ((table['actionParams'] | length == 0))))  %}
 /**
  * @brief Attribute data for #SAI_{{ table.name | upper }}_ATTR_ACTION
  */
@@ -113,7 +113,7 @@ typedef enum _sai_{{ table.name }}_attr_t
     SAI_{{ table.name | upper }}_ATTR_START,
 
 {% set ns = namespace(firstattr=false) %}
-{% if table.actions | length > 1 %}
+{% if table.actions | length > 1 or ((table.actions | length == 1) and (((table.is_object == 'false') or (table['keys'] | length <= 1)) and ((table['actionParams'] | length == 0))))  %}
     /**
      * @brief Action
      *

--- a/dash-pipeline/bmv2/dash_pipeline.p4
+++ b/dash-pipeline/bmv2/dash_pipeline.p4
@@ -43,7 +43,7 @@ control dash_ingress(inout headers_t hdr,
 
         actions = {
             accept;
-            deny;
+            @defaultonly deny;
         }
 
         const default_action = deny;
@@ -175,7 +175,7 @@ control dash_ingress(inout headers_t hdr,
 
         actions = {
             permit;
-            deny;
+            @defaultonly deny;
         }
 
         const default_action = deny;


### PR DESCRIPTION
Fixes #147 task 2 allowing to add @defaultonly tag to vip and pa_validation table deny actions

SAI api header change - removes the following actions
```
    SAI_VIP_ENTRY_ACTION_DENY
    SAI_PA_VALIDATION_ENTRY_ACTION_DENY
```