### PR TITLE
Publish docker images to ACR and use those in build process.

### DIFF
--- a/.github/workflows/dash-bmv2-bldr-docker-acr.yml
+++ b/.github/workflows/dash-bmv2-bldr-docker-acr.yml
@@ -1,38 +1,38 @@
-name: DASH-docker-p4c-bmv2-build-publish-acr
+name: DASH-docker-bmv2-bldr-build-publish-acr
+
 
 on:
   push:
     branches: [ "**" ]
     paths:
-      - '.github/workflows/dash-p4c-bmv2-docker-acr.yml'
-      - 'dash-pipeline/dockerfiles/Dockerfile.p4c-bmv2'
+      - '.github/workflows/dash-bmv2-bldr-docker-acr.yml'
+      - 'dash-pipeline/dockerfiles/Dockerfile.bmv2-bldr'
       - 'dash-pipeline/.dockerignore'
       - 'dash-pipeline/dockerfiles/.dockerignore'
   pull_request:
     branches: [ "main" ]
     paths:
-      - '.github/workflows/dash-p4c-bmv2-docker-acr.yml'
-      - 'dash-pipeline/dockerfiles/Dockerfile.p4c-bmv2'
+      - '.github/workflows/dash-bmv2-bldr-docker-acr.yml'
+      - 'dash-pipeline/dockerfiles/Dockerfile.bmv2-bldr'
       - 'dash-pipeline/.dockerignore'
       - 'dash-pipeline/dockerfiles/.dockerignore'
   workflow_dispatch:
 
 jobs:
   build:
-    name: Build and publish docker dash-p4c-bmv2 image
+    name: Build and publish docker dash-bmv2-bldr image
     runs-on: ubuntu-20.04
-    
     defaults:
       run:
         working-directory: ./dash-pipeline
     steps:
     - uses: actions/checkout@v3
-    - name: Build dash-p4c-bmv2 docker image
-      run: make docker-dash-p4c
+    - name: Build dash-bmv2-bldr docker image
+      run: make docker-bmv2-bldr
     - uses: azure/docker-login@v1
       with:
         login-server: ${{ secrets.DASH_ACR_LOGIN_SERVER }}
         username: ${{ secrets.DASH_ACR_USERNAME }}
         password: ${{ secrets.DASH_ACR_PASSWORD }}    
-    - name: Publish dash-p4c-bmv2 docker image to ACR
-      run: docker push sonicdash.azurecr.io/dash-p4c-bmv2:220819
+    - name: Publish dash-bmv2-bldr image
+      run: docker push sonicdash.azurecr.io/dash-bmv2-bldr:220630

--- a/.github/workflows/dash-saithrift-bldr-docker-acr.yml
+++ b/.github/workflows/dash-saithrift-bldr-docker-acr.yml
@@ -1,0 +1,44 @@
+name: DASH-docker-saithrift-bldr-build-publish-acr
+
+on:
+  push:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/dash-saithrift-bldr-docker-acr.yml'
+      - 'dash-pipeline/Makefile'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/dash-saithrift-bldr-docker-acr.yml'
+      - 'dash-pipeline/Makefile'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and publish dash-saithrift-bldr-image
+    runs-on: ubuntu-20.04
+    env:
+      docker_fg_flags: -u root --privileged
+      docker_bg_flags: -d -u root --privileged
+    defaults:
+      run:
+        working-directory: ./dash-pipeline
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and publish docker-saithrift-bldr image
+      run:  make docker-saithrift-bldr
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.DASH_ACR_LOGIN_SERVER }}
+        username: ${{ secrets.DASH_ACR_USERNAME }}
+        password: ${{ secrets.DASH_ACR_PASSWORD }}    
+    - name: Build dash-saithrift-bldr image 
+      run:  DOCKER_FLAGS=$docker_fg_flags make docker-saithrift-bldr
+    - name: Publish dash-saithrift-bldr docker image
+      run: docker push sonicdash.azurecr.io/dash-saithrift-bldr:220719

--- a/.github/workflows/dash-saithrift-bldr-docker.yml
+++ b/.github/workflows/dash-saithrift-bldr-docker.yml
@@ -1,0 +1,44 @@
+name: DASH-docker-saithrift-bldr-image
+
+on:
+  push:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/dash-saithrift-bldr-docker.yml'
+      - 'dash-pipeline/Makefile'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/dash-saithrift-bldr-docker.yml'
+      - 'dash-pipeline/Makefile'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and publish dash-saithrift-bldr-image
+    runs-on: ubuntu-20.04
+    env:
+      docker_fg_flags: -u root --privileged
+      docker_bg_flags: -d -u root --privileged
+    defaults:
+      run:
+        working-directory: ./dash-pipeline
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and publish docker-saithrift-bldr image
+      run:  make docker-saithrift-bldr
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.DASH_ACR_LOGIN_SERVER }}
+        username: ${{ secrets.DASH_ACR_USERNAME }}
+        password: ${{ secrets.DASH_ACR_PASSWORD }}    
+    - name: Build dash-saithrift-bldr image 
+      run:  DOCKER_FLAGS=$docker_fg_flags make docker-saithrift-bldr
+    - name: Publish dash-saithrift-bldr docker image
+      run: docker push sonicdash.azurecr.io/dash-saithrift-bldr:220719

--- a/.github/workflows/dash-saithrift-bldr-docker.yml
+++ b/.github/workflows/dash-saithrift-bldr-docker.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    name: Build and publish dash-saithrift-bldr-image
+    name: Build dash-saithrift-bldr-image
     runs-on: ubuntu-20.04
     env:
       docker_fg_flags: -u root --privileged
@@ -31,14 +31,5 @@ jobs:
         working-directory: ./dash-pipeline
     steps:
     - uses: actions/checkout@v3
-    - name: Build and publish docker-saithrift-bldr image
+    - name: Build docker-saithrift-bldr image
       run:  make docker-saithrift-bldr
-    - uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.DASH_ACR_LOGIN_SERVER }}
-        username: ${{ secrets.DASH_ACR_USERNAME }}
-        password: ${{ secrets.DASH_ACR_PASSWORD }}    
-    - name: Build dash-saithrift-bldr image 
-      run:  DOCKER_FLAGS=$docker_fg_flags make docker-saithrift-bldr
-    - name: Publish dash-saithrift-bldr docker image
-      run: docker push sonicdash.azurecr.io/dash-saithrift-bldr:220719

--- a/.github/workflows/dash-saithrift-client-bldr-docker-acr.yml
+++ b/.github/workflows/dash-saithrift-client-bldr-docker-acr.yml
@@ -1,0 +1,54 @@
+name: DASH-docker-saithrift-client-bldr-build-publish-acr
+
+on:
+  push:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/dash-saithrift-client-bldr-docker-acr.yml'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-client-bldr'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '.github/workflows/dash-saithrift-client-bldr-docker-acr.yml'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-bldr'
+      - 'dash-pipeline/dockerfiles/Dockerfile.saithrift-client-bldr'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and publish dash-saithrift-client-bldr-image
+    runs-on: ubuntu-20.04
+    env:
+      docker_fg_flags: -u root --privileged
+      docker_bg_flags: -d -u root --privileged
+    defaults:
+      run:
+        working-directory: ./dash-pipeline
+    steps:
+    - uses: actions/checkout@v3
+    - name: Pull docker p4c image
+      run:  make docker-pull-dash-p4c
+    - name: Build P4 software switch (bmv2) and P4Info
+      run:  DOCKER_FLAGS=$docker_fg_flags make p4
+    - name: Install SAI submodule
+      run:  git submodule update --init
+    - name: Build docker-saithrift-bldr image
+      run:  make docker-saithrift-bldr
+    - name: Generate SAI API
+      run:  DOCKER_FLAGS=$docker_fg_flags make sai
+    - name: Generate SAI-Thrift client and server code and libs
+      run:  DOCKER_FLAGS=$docker_fg_flags make saithrift-server
+    - uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.DASH_ACR_LOGIN_SERVER }}
+        username: ${{ secrets.DASH_ACR_USERNAME }}
+        password: ${{ secrets.DASH_ACR_PASSWORD }}    
+    - name: Build dash-saithrift-client-bldr image 
+      run:  DOCKER_FLAGS=$docker_fg_flags make docker-saithrift-client-bldr
+    - name: Publish dash-saithrift-client-bldr docker image
+      run: docker push sonicdash.azurecr.io/dash-saithrift-client-bldr:220723

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -25,22 +25,22 @@ PWD := $(shell pwd)
 DASH_ACR_REGISTRY ?=sonicdash.azurecr.io
 
 # Needed Libraries only
-DOCKER_GRPC_IMG ?=chrissommers/dash-grpc:1.43.2
+DOCKER_GRPC_IMG ?=$(DASH_ACR_REGISTRY)/dash-grpc:1.43.2
 
 # Slimmed-down version bmv2 backend only 632MB - works:
 DOCKER_P4C_BMV2_IMG ?=$(DASH_ACR_REGISTRY)/dash-p4c-bmv2:220819
 
 # Builds sai-P4rt clients to run inside bmvs process
-DOCKER_BMV2_BLDR_IMG ?=chrissommers/dash-bmv2-bldr:220630
+DOCKER_BMV2_BLDR_IMG ?=$(DASH_ACR_REGISTRY)/dash-bmv2-bldr:220630
 
 # Runs bmv2 process - consider slimmer if don't need sai/p4rt clients inside
 DOCKER_BMV2_RUN_IMG ?=$(DOCKER_BMV2_BLDR_IMG)
 
 # Compiles sai headers, libsai, saithrift server & client/server libs
-DOCKER_SAITHRIFT_BLDR_IMG ?=chrissommers/dash-saithrift-bldr:220719
+DOCKER_SAITHRIFT_BLDR_IMG ?=$(DASH_ACR_REGISTRY)/dash-saithrift-bldr:220719
 
 # Base image with test frameworks, DASH client libs not installed
-DOCKER_SAITHRIFT_CLIENT_BLDR_IMG ?=chrissommers/dash-saithrift-client-bldr:220723
+DOCKER_SAITHRIFT_CLIENT_BLDR_IMG ?=$(DASH_ACR_REGISTRY)/dash-saithrift-client-bldr:220723
 
 # Client image built locally with saithrift client libs + PTF & Pytest frameworks
 # TODO: consider some other tagging scheme
@@ -294,9 +294,6 @@ docker-bmv2-bldr:
 	    --build-arg available_processors=$(shell nproc) \
 	    dockerfiles
 
-docker-publish-bmv2-bldr:
-	echo "TO DO when we have a proper repository"
-
 docker-pull-bmv2-bldr:
 	docker pull $(DOCKER_BMV2_BLDR_IMG)
 ###############################
@@ -310,9 +307,6 @@ docker-saithrift-bldr:
 	    --build-arg hostname=$(shell echo $$HOSTNAME) \
 	    --build-arg available_processors=$(shell nproc) \
 		dockerfiles
-
-docker-publish-saithrift-bldr:
-	echo "TO DO when we have a proper repository"
 
 docker-pull-saithrift-bldr:
 	docker pull $(DOCKER_SAITHRIFT_BLDR_IMG)
@@ -332,9 +326,6 @@ docker-saithrift-client-bldr:
 
 docker-pull-saithrift-client-bldr:
 	docker pull $(DOCKER_SAITHRIFT_CLIENT_BLDR_IMG)
-
-docker-publish-saithrift-client-bldr:
-	echo "TO DO when we have a proper repository"
 
 ###############################
 		
@@ -409,8 +400,6 @@ docker-dash-p4c:
 docker-pull-dash-p4c:
 	docker pull $(DOCKER_P4C_BMV2_IMG)
 
-docker-publish-dash-p4c:
-	echo "TO DO when we have a proper repository"
 ###############################
 
 docker-dash-grpc:
@@ -426,9 +415,6 @@ docker-dash-grpc:
 
 docker-pull-dash-grpc:
 	docker pull $(DOCKER_GRPC_IMG)
-
-docker-publish-dash-grpc:
-	echo "TO DO when we have a proper repository"
 
 ###############################
 # BMV2-PKTGEN NETWORKING TARGETS


### PR DESCRIPTION
Build processes which publish to ACR must be run from DASH repo or a branch; forks don't have access to ACR secrets. This incremental commit pushes changes to DASH `publish-dockers-to-acr` branch to result in publishing and consuming all docker images using Azure Container REgistry (ACR).

Some actions will fail on the first pass until images get published, because they pull from same ACR registry. It's a chicken-and-egg problem which will be solved in subsequent changes.