### PR TITLE
allow vendor specific lib for saithrift server compile

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -281,7 +281,9 @@ Keysight
 KVM
 kvm
 lang
+LIBS
 libsai
+libprotobuf
 linux
 liveness
 LLDP
@@ -441,6 +443,7 @@ rx
 SAI
 sai
 sairedis
+SAIRPC
 saiserver
 saithrift
 sata

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -1,5 +1,8 @@
 SHELL = /bin/bash
 
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
 # "All" type targets for convenience
 all:p4 sai saithrift-server docker-saithrift-client test
 
@@ -13,7 +16,7 @@ clean: kill-all p4-clean sai-clean test-clean network-clean saithrift-server-cle
 
 kill-all: kill-saithrift-server kill-switch undeploy-ixiac
 
-PWD := $(shell pwd)
+PWD := $(realpath $(mkfile_dir))
 DASH_USER ?=dashuser
 DASH_GROUP ?=dashusers
 DASH_UID ?=4321
@@ -102,7 +105,7 @@ $(P4_ARTIFACTS): $(P4_SRC)
 # DASH SAI HEADER & libsai.so TARGETS
 ######################################
 
-
+SAIRPC_VENDOR_EXTRA_LIBS?=""
 # Note we have to mount main DASH dir to allow container to "see" the parent Git repo for the SAI submodule
 DOCKER_RUN_SAITHRIFT_BLDR =\
 	docker run \
@@ -110,6 +113,7 @@ DOCKER_RUN_SAITHRIFT_BLDR =\
 	--rm \
 	--name dash-saithrift-bldr-$(USER) \
 	-v $(PWD)/..:/dash -w /dash/dash-pipeline/SAI/saithrift \
+	-e SAIRPC_VENDOR_EXTRA_LIBS=$(SAIRPC_VENDOR_EXTRA_LIBS) \
 	$(DOCKER_SAITHRIFT_BLDR_IMG) \
 
 # TODO - create separate rules for headers, libsai.so

--- a/dash-pipeline/README-dash-workflows.md
+++ b/dash-pipeline/README-dash-workflows.md
@@ -253,7 +253,7 @@ Its value will be added to the baseline SAIRPC_EXTRA_LIBS as defined in the sait
 
 Since the saithrift server is built within a docker container (and the parent repository is mounted as /dash), any of the extra libraries needed will need to be copied over under the parent repository, and the paths to those libraries will need to be relative to the docker mount point.
 
-In the example below, libprotobuf.a is a new external dependancy to the vendor specific libsai.so and has been copied over under the parent repository (in our case, dash-pipeline/SAI/lib).
+In the example below, libprotobuf.a is a new external dependency to the vendor specific libsai.so and has been copied over under the parent repository (in our case, dash-pipeline/SAI/lib).
 We use the provided Makefile.3rdpty as an entry point into the DASH makefiles.
 
 ```

--- a/dash-pipeline/README-dash-workflows.md
+++ b/dash-pipeline/README-dash-workflows.md
@@ -247,6 +247,23 @@ This builds a saithrift-server daemon, which is linked to the `libsai` library a
 ```
 make saithrift-server
 ```
+In the case a vendor integrates its own `libsai` library into the saithrift server, the libsai might have new external dependencies (such as google protocol buffer) thus requiring for vendor specific libraries or linker options to be passed down to the saiserver linker.
+An environment variable (SAIRPC_VENDOR_EXTRA_LIBS) can be specified when invoking the saithrift server build command to provide path to new libraries and/or new linker options.
+Its value will be added to the baseline SAIRPC_EXTRA_LIBS as defined in the saithrift makefile.
+
+Since the saithrift server is built within a docker container (and the parent repository is mounted as /dash), any of the extra libraries needed will need to be copied over under the parent repository, and the paths to those libraries will need to be relative to the docker mount point.
+
+In the example below, libprotobuf.a is a new external dependancy to the vendor specific libsai.so and has been copied over under the parent repository (in our case, dash-pipeline/SAI/lib).
+We use the provided Makefile.3rdpty as an entry point into the DASH makefiles.
+
+```
+SAIRPC_VENDOR_EXTRA_LIBS="/dash/dash-pipeline/SAI/lib/libprotobuf.a"
+thirdparty-saithrift-server: thirdparty-libsai
+	@echo "Build third-party saithrift-server"
+	@echo "   Expects libsai.so under $(DASHDIR)/dash-pipeline/SAI/lib"
+	SAIRPC_VENDOR_EXTRA_LIBS=$(SAIRPC_VENDOR_EXTRA_LIBS) $(MAKE) -C $(DASHDIR)/dash-pipeline saithrift-server
+```
+
 ## Build libsai C++ client test program(s)
 This compiles simple libsai client program(s) to verify the libsai-to-p4runtime-to-bmv2 stack. It performs table access(es).
 

--- a/dash-pipeline/SAI/saithrift/Makefile
+++ b/dash-pipeline/SAI/saithrift/Makefile
@@ -7,7 +7,8 @@ RPC_INST_DIR=$(shell pwd)/../rpc
 
 META=../SAI/meta
 
-SAIRPC_EXTRA_LIBS="\
+SAIRPC_VENDOR_EXTRA_LIBS?=
+SAIRPC_EXTRA_LIBS= "$(SAIRPC_VENDOR_EXTRA_LIBS) \
 		-L/lib/x86_64-linux-gnu -Wl,-rpath=/lib/x86_64-linux-gnu -lm \
 		-L/usr/local/lib/ -Wl,-rpath=/usr/local/lib \
 	    -lpthread \


### PR DESCRIPTION
when building a vendor specific libsai.so to link into the saithrift server, we might need extra libraries to finalize the saiserver executable, e.g. dependency on google protocol buffer specific library.
by setting a new environment variable, the dash-pipeline makefile will make sure that
1/ this variable is passed via docker to the saithrift server docker run
2/ the saithrift server makefile uses this env variable to expand the linker compile flags.

example usage from thirdparty makefile

SAIRPC_VENDOR_EXTRA_LIBS="/dash/dash-pipeline/SAI/lib/libprotobuf.a"
thirdparty-saithrift-server: thirdparty-libsai
	@echo "Build third-party saithrift-server"
	@echo "   Expects libsai.so under $(DASHDIR)/dash-pipeline/SAI/lib"
	SAIRPC_VENDOR_EXTRA_LIBS=$(SAIRPC_VENDOR_EXTRA_LIBS) $(MAKE) -C $(DASHDIR)/dash-pipeline saithrift-server

misc:
modify the dash-pipeline makefile to guarantee PWD is the makefile location, no matter where it's called from.