### PR TITLE
Make SAI attrs mandatory for drop-on-miss tables

### DIFF
--- a/dash-pipeline/SAI/sai_api_gen.py
+++ b/dash-pipeline/SAI/sai_api_gen.py
@@ -233,11 +233,21 @@ def generate_sai_apis(program, ignore_tables):
                         break
 
         param_names = []
+        deny_on_miss = False
         for action in table[ACTION_REFS_TAG]:
             action_id = action["id"]
-            if all_actions[action_id][NAME_TAG] != NOACTION and not (SCOPE_TAG in action and action[SCOPE_TAG] == 'DEFAULT_ONLY'):
-                fill_action_params(sai_table_data[ACTION_PARAMS_TAG], param_names, all_actions[action_id])
-                sai_table_data[ACTIONS_TAG].append(all_actions[action_id])
+            if all_actions[action_id][NAME_TAG] == NOACTION:
+                continue
+
+            if (SCOPE_TAG in action and action[SCOPE_TAG] == 'DEFAULT_ONLY'):
+                if all_actions[action_id][NAME_TAG] == 'deny':
+                    deny_on_miss = True
+                continue
+
+            fill_action_params(sai_table_data[ACTION_PARAMS_TAG], param_names, all_actions[action_id])
+            sai_table_data[ACTIONS_TAG].append(all_actions[action_id])
+
+        sai_table_data['deny_on_miss'] = 'true' if deny_on_miss else 'false'
 
         if len(sai_table_data['keys']) == 1 and sai_table_data['keys'][0]['sai_key_name'].endswith(table_name.split('.')[-1] + '_id'):
             sai_table_data['is_object'] = 'true'
@@ -371,6 +381,15 @@ def write_sai_files(sai_api):
         f.write(''.join(new_lines))
 
 
+def is_table_deny_on_miss(sai_apis, table_name):
+    for sai_api in sai_apis:
+        for table in sai_api[TABLES_TAG]:
+            if table[NAME_TAG] == table_name:
+                print(table_name, table['deny_on_miss'])
+                return table['deny_on_miss'] == 'true'
+    return False
+
+
 
 # CLI
 parser = argparse.ArgumentParser(description='P4 SAI API generator')
@@ -403,6 +422,8 @@ for sai_api in sai_apis:
                 for table_name in all_table_names:
                     if table_ref.endswith(table_name):
                         param[OBJECT_NAME_TAG] = table_name
+                        if is_table_deny_on_miss(sai_apis, table_name):
+                            param['mandatory'] = 'true'
     # Update object name reference for keys
     for table in sai_api[TABLES_TAG]:
         for key in table['keys']:
@@ -412,6 +433,8 @@ for sai_api in sai_apis:
                     for table_name in all_table_names:
                         if table_ref.endswith(table_name):
                             key[OBJECT_NAME_TAG] = table_name
+                            if is_table_deny_on_miss(sai_apis, table_name):
+                                key['mandatory'] = 'true'
     # Write SAI dictionary into SAI API headers
     write_sai_files(sai_api)
     write_sai_impl_files(sai_api)

--- a/dash-pipeline/SAI/templates/saiapi.h.j2
+++ b/dash-pipeline/SAI/templates/saiapi.h.j2
@@ -118,7 +118,7 @@ typedef enum _sai_{{ table.name }}_attr_t
      * @brief Action
      *
      * @type sai_{{ table.name }}_action_t
-     * @flags CREATE_AND_SET
+     * @flags CREATE_ONLY
      * @default SAI_{{ table.name | upper }}_ACTION_{{ table.actions[0].name | upper }}
      */
     SAI_{{ table.name | upper }}_ATTR_ACTION = SAI_{{ table.name | upper }}_ATTR_START,
@@ -163,10 +163,21 @@ typedef enum _sai_{{ table.name }}_attr_t
      * @brief Action {% for action in param.paramActions %}{{ action }}{{ ", " if not loop.last else "" }}{% endfor %} parameter {{ param.name | upper }}
      *
      * @type {{ param.type }}
+{% if param.mandatory == 'true' %}
+     * @flags MANDATORY_ON_CREATE | CREATE_AND_SET
+{% else %}
      * @flags CREATE_AND_SET
+{% endif %}
 {% if param.type == 'sai_uint16_t' %}
      * @isvlan false
 {% endif %}
+{% if param.type == 'sai_object_id_t' %}
+     * @objects SAI_OBJECT_TYPE_{{ param.objectName | upper }}
+{% if param.mandatory != 'true' %}
+     * @allownull true
+{% endif %}
+{% endif %}
+{% if param.mandatory != 'true' %}
 {% if param.type == 'sai_ip_address_t' %}
      * @default 0.0.0.0
 {% elif param.type == 'sai_ip_addr_family_t' %}
@@ -176,15 +187,14 @@ typedef enum _sai_{{ table.name }}_attr_t
 {% elif param.type == 'bool' %}
      * @default false
 {% elif param.type == 'sai_object_id_t' %}
-     * @objects SAI_OBJECT_TYPE_{{ param.objectName | upper }}
-     * @allownull true
      * @default SAI_NULL_OBJECT_ID
 {% else %}
      * @default 0
 {% endif %}
+{% endif %}
 {% if table.actions | length > 1 %}
 {% if param.paramActions | length > 0 %}
-     * @validonly {% for action in param.paramActions %}SAI_{{ table.name | upper }}_ATTR_ACTION == SAI_{{ table.name | upper }}_ACTION_{{ action | upper }}{{ " or " if not loop.last else "" }}{% endfor %}
+     * {% if param.mandatory == 'true' %}@condition{% else %}@validonly{% endif %} {% for action in param.paramActions %}SAI_{{ table.name | upper }}_ATTR_ACTION == SAI_{{ table.name | upper }}_ACTION_{{ action | upper }}{{ " or " if not loop.last else "" }}{% endfor %}
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
If a table references another table (ENI->VNET_ID) where VNET table drops on miss, the SAI attribute VNET_ID in the ENI will be mandatory on create.

Omitting this attribute will no longer be allowed.

Signed-off-by: Marian Pritsak <marianp@mellanox.com>