### PR TITLE
Add bmv2 libsai switch & port attributes

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -244,7 +244,7 @@ test-clean:
 
 .PHONY:libsai-test
 libsai-test:SAI/SAI SAI/lib/libsai.so
-	# chmod -R a+w tests/libsai
+	chmod -R a+w tests/libsai
 	$(DOCKER_RUN) \
 	    --name dash-build-test-$(USER) \
 		-w /tests/libsai  $(DOCKER_BMV2_BLDR_IMG) \

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -244,7 +244,7 @@ test-clean:
 
 .PHONY:libsai-test
 libsai-test:SAI/SAI SAI/lib/libsai.so
-	chmod -R a+w tests/libsai
+	# chmod -R a+w tests/libsai
 	$(DOCKER_RUN) \
 	    --name dash-build-test-$(USER) \
 		-w /tests/libsai  $(DOCKER_BMV2_BLDR_IMG) \

--- a/dash-pipeline/SAI/templates/utils.cpp.j2
+++ b/dash-pipeline/SAI/templates/utils.cpp.j2
@@ -217,12 +217,78 @@ sai_status_t sai_create_switch_dummy(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t sai_get_switch_attribute_dummy(
+#define DASH_BMV2_NUM_PORTS 2 
+#define DASH_BMV2_CPU_QOS_NUMBER_OF_QUEUES 0
+#define DASH_BMV2_DEFAULT_CPU_PORT_ID (sai_object_id_t)((SAI_OBJECT_TYPE_PORT<<48)+1)
+#define DASH_BMV2_DEFAULT_VLAN_ID (sai_object_id_t)((SAI_OBJECT_TYPE_VLAN<<48)+1)
+#define DASH_BMV2_DEFAULT_VRF_ID (sai_object_id_t)((SAI_OBJECT_TYPE_VIRTUAL_ROUTER<<48)+1)
+#define DASH_BMV2_DEFAULT_1Q_BRIDGE_ID (sai_object_id_t)((SAI_OBJECT_TYPE_BRIDGE<<48)+1)
+#define DASH_BMV2_DEFAULT_1Q_BRIDGE_ID (sai_object_id_t)((SAI_OBJECT_TYPE_BRIDGE<<48)+1)
+
+sai_object_id_t port_list[DASH_BMV2_NUM_PORTS] = {
+    (sai_object_id_t)((SAI_OBJECT_TYPE_PORT<<48) + 1),
+    (sai_object_id_t)((SAI_OBJECT_TYPE_PORT<<48) + 2)
+};
+
+sai_status_t sai_get_switch_attribute(
         _In_ sai_object_id_t switch_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list) {
 
-    fprintf(stderr, "sai_get_switch_attribute_dummy()\n");
+    fprintf(stderr, "sai_get_switch_attribute()\n");
+    int i;
+    sai_attribute_t *attr = attr_list;
+    sai_object_list_t port_obj_list;
+    sai_object_id_t *objlist;
+    for (i = 0; i < attr_count ; i++, attr++) {
+        switch(attr->id) {
+        
+        case SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS:
+            attr->value.u32 = DASH_BMV2_NUM_PORTS;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS = %d\n",
+                    i, attr->id, attr->value.u32);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_PORT_LIST:
+            // make a tmp port list, saiserver will free the memory
+            objlist = (sai_object_id_t *)malloc(sizeof(port_list));
+            memcpy(objlist, port_list, sizeof(port_list));
+            port_obj_list = {
+                .count = DASH_BMV2_NUM_PORTS,
+                .list = objlist
+            };                
+            attr->value.objlist = port_obj_list;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d SAI_SWITCH_ATTR_PORT_LIST = [%d objids]\n",
+                    i, attr->id, DASH_BMV2_NUM_PORTS);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_DEFAULT_VLAN_ID:
+            attr->value.oid = DASH_BMV2_DEFAULT_VLAN_ID;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d SAI_SWITCH_ATTR_DEFAULT_VLAN_ID = %lx\n",
+                    i, attr->id, attr->value.oid);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID:
+            attr->value.oid = DASH_BMV2_DEFAULT_VRF_ID;
+            fprintf(stderr, "  sai_get_switch_attribute() [0] attr %d SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID = %lx\n", attr->id, attr->value.oid);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID:
+            attr->value.oid = DASH_BMV2_DEFAULT_1Q_BRIDGE_ID;
+            fprintf(stderr, "  sai_get_switch_attribute() [0] attr %d SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID = %lx\n", attr->id, attr->value.oid);
+            return SAI_STATUS_SUCCESS;
+
+        case SAI_SWITCH_ATTR_CPU_PORT:
+            attr->value.oid = DASH_BMV2_DEFAULT_CPU_PORT_ID;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d DASH_BMV2_DEFAULT_CPU_PORT_ID = %lx\n",
+                    i, attr->id, attr->value.oid);
+            return SAI_STATUS_SUCCESS;
+
+        default:
+            fprintf(stderr, "  sai_get_switch_attribute() [0] attr %d is NOT SUPPORTED - returning SAI_STATUS_SUCCESS anyway\n", attr->id);
+            return SAI_STATUS_SUCCESS;
+        }
+    }
     return SAI_STATUS_SUCCESS;
 }
 
@@ -230,7 +296,7 @@ sai_switch_api_t sai_switch_api_impl = {
     .create_switch = sai_create_switch_dummy,
     .remove_switch = (void *)0,
     .set_switch_attribute = (void *)0,
-    .get_switch_attribute = sai_get_switch_attribute_dummy,
+    .get_switch_attribute = sai_get_switch_attribute,
     .get_switch_stats = (void *)0,
     .get_switch_stats_ext = (void *)0,
     .clear_switch_stats = (void *)0,
@@ -240,6 +306,62 @@ sai_switch_api_t sai_switch_api_impl = {
     .remove_switch_tunnel = (void *)0,
     .set_switch_tunnel_attribute = (void *)0,
     .get_switch_tunnel_attribute = (void *)0
+};
+
+
+sai_status_t sai_get_port_attribute(
+        _In_ sai_object_id_t port_id,
+        _In_ uint32_t attr_count,
+        _Inout_ sai_attribute_t *attr_list) {
+
+    fprintf(stderr, "sai_get_port_attribute()\n");
+    int i;
+    sai_attribute_t *attr = attr_list;
+
+    for (i = 0; i < attr_count ; i++, attr++) {
+        switch(attr->id) {
+        case SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES:
+            attr->value.u32 = DASH_BMV2_CPU_QOS_NUMBER_OF_QUEUES;
+            fprintf(stderr, "  sai_get_port_attribute() [0] attr %d SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES = %d\n", attr->id, attr->value.u32);
+            return SAI_STATUS_SUCCESS;
+
+        default:
+            fprintf(stderr, "  sai_get_port_attribute() [0] attr %d is NOT SUPPORTED - returning SAI_STATUS_SUCCESS anyway\n", attr->id);
+            return SAI_STATUS_SUCCESS;
+        }
+    }
+
+    return SAI_STATUS_SUCCESS;
+}
+
+sai_port_api_t sai_port_api_impl = {
+    .create_port = (void *)0,
+    .remove_port = (void *)0,
+    .set_port_attribute = (void *)0,
+    .get_port_attribute = sai_get_port_attribute,
+    .get_port_stats = (void *)0,
+    .get_port_stats_ext = (void *)0,
+    .clear_port_stats = (void *)0,
+    .clear_port_all_stats = (void *)0,
+    .create_port_pool = (void *)0,
+    .remove_port_pool = (void *)0,
+    .set_port_pool_attribute = (void *)0,
+    .get_port_pool_attribute = (void *)0,
+    .get_port_pool_stats = (void *)0,
+    .get_port_pool_stats_ext = (void *)0,
+    .clear_port_pool_stats = (void *)0,
+    .create_port_connector = (void *)0,
+    .remove_port_connector = (void *)0,
+    .set_port_connector_attribute = (void *)0,
+    .get_port_connector_attribute = (void *)0,
+    .create_port_serdes = (void *)0,
+    .remove_port_serdes = (void *)0,
+    .set_port_serdes_attribute = (void *)0,
+    .get_port_serdes_attribute = (void *)0,
+    .create_ports = (void *)0,
+    .remove_ports = (void *)0,
+    .set_ports_attribute = (void *)0,
+    .get_ports_attribute = (void *)0
 };
 
 
@@ -255,6 +377,10 @@ sai_status_t sai_api_query(
         switch(api) {
         case SAI_API_SWITCH:
             *api_method_table = (void *)&sai_switch_api_impl;
+            break;
+        
+        case SAI_API_PORT:
+            *api_method_table = (void *)&sai_port_api_impl;
             break;
         
 {% for api in api_names %}
@@ -298,5 +424,3 @@ sai_status_t sai_api_initialize(
 sai_status_t sai_log_set(
         _In_ sai_api_t api,
         _In_ sai_log_level_t log_level) { return SAI_STATUS_SUCCESS; }
-
-

--- a/dash-pipeline/tests/saithrift/ptf/thrift/test_thrift_session.py
+++ b/dash-pipeline/tests/saithrift/ptf/thrift/test_thrift_session.py
@@ -1,7 +1,7 @@
 from sai_thrift.sai_headers import *
 from sai_base_test import *
 
-class TestSaiThriftSession(ThriftInterfaceDataPlane):
+class TestSaiThriftSession(SaiHelperSimplified):
     """ Test saithrift client connection only"""
     def setup(self):
         print ("setup()")
@@ -13,65 +13,7 @@ class TestSaiThriftSession(ThriftInterfaceDataPlane):
     def teardown(self):
         print ("teardown()")
 
-# TODO - need to implement some DASH switch APIs to get switch attributes etc.
-# We need this to run traditional PTF tests which depend upon device attributes etc.
-
-# class TestSaiThriftSaiHelper(SaiHelper):
-
-#  Using SaiHelper base class, we get this (because vlan default = 0)
-# root@chris-z4:/saithrift-host# ./run-saithrift-ptftests.sh 
-# /usr/local/lib/python3.8/dist-packages/ptf-0.9.1-py3.8.egg/EGG-INFO/scripts/ptf:19: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
-#   import imp
-# test_thrift_session.TestThriftSession ... ***** Number of available resources *****
-# SAI_SWITCH_ATTR_ECMP_MEMBERS :  0
-# ecmp_members :  0
-# SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS :  0
-# number_of_ecmp_groups :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY :  0
-# available_ipv4_route_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPV6_ROUTE_ENTRY :  0
-# available_ipv6_route_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY :  0
-# available_ipv4_nexthop_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY :  0
-# available_ipv6_nexthop_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEIGHBOR_ENTRY :  0
-# available_ipv4_neighbor_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEIGHBOR_ENTRY :  0
-# available_ipv6_neighbor_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_ENTRY :  0
-# available_next_hop_group_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_MEMBER_ENTRY :  0
-# available_next_hop_group_member_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY :  0
-# available_fdb_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_IPMC_ENTRY :  0
-# available_ipmc_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY :  0
-# available_snat_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY :  0
-# available_dnat_entry :  0
-# SAI_SWITCH_ATTR_AVAILABLE_DOUBLE_NAT_ENTRY :  0
-# available_double_nat_entry :  0
-# FAIL
-
-# ======================================================================
-# FAIL: test_thrift_session.TestThriftSession
-# ----------------------------------------------------------------------
-# Traceback (most recent call last):
-#   File "/saithrift-host/../../SAI/ptf/sai_base_test.py", line 654, in setUp
-#     super(SaiHelper, self).setUp()
-#   File "/saithrift-host/../../SAI/ptf/sai_base_test.py", line 304, in setUp
-#     self.assertNotEqual(self.default_vlan_id, 0)
-# AssertionError: 0 == 0
-
-# ----------------------------------------------------------------------
-# Ran 1 test in 0.021s
-
-# FAILED (failures=1)
-
-# TODO - temporary until fix per above:
-class TestSaiThriftSaiHelper(ThriftInterfaceDataPlane):
+class TestSaiThriftSaiHelper(SaiHelperSimplified):
     """ Test saithrift client connection and basic SaiHelper intitialization"""
     def setup(self):
         print ("setup()")

--- a/dash-pipeline/tests/saithrift/ptf/vnet/test_saithrift_vnet.py
+++ b/dash-pipeline/tests/saithrift/ptf/vnet/test_saithrift_vnet.py
@@ -1,9 +1,7 @@
 from sai_thrift.sai_headers import *
 from sai_base_test import *
-# TODO - when switch APIs implemented:
-# class TestSaiThrift_outbound_udp_pkt(SaiHelper):
 
-class TestSaiThrift_outbound_udp_pkt(ThriftInterfaceDataPlane):
+class TestSaiThrift_outbound_udp_pkt(SaiHelperSimplified):
     """ Test saithrift vnet outbound"""
     def setUp(self):
         super(TestSaiThrift_outbound_udp_pkt, self).setUp()

--- a/dash-pipeline/tests/saithrift/ptf/vnet/test_saithrift_vnet_v6.py
+++ b/dash-pipeline/tests/saithrift/ptf/vnet/test_saithrift_vnet_v6.py
@@ -1,9 +1,7 @@
 from sai_thrift.sai_headers import *
 from sai_base_test import *
-# TODO - when switch APIs implemented:
-# class TestSaiThrift_outbound_udp_pkt(SaiHelper):
 
-class TestSaiThrift_outbound_udpv6_pkt(ThriftInterfaceDataPlane):
+class TestSaiThrift_outbound_udpv6_pkt(SaiHelperSimplified):
     """ Test saithrift vnet outbound"""
     def setUp(self):
         super(TestSaiThrift_outbound_udpv6_pkt, self).setUp()


### PR DESCRIPTION
Fixes #235. Added fake switch & port attributes to bmv2 libsai in order to satisfy PyTest and PTF base classes. Use `SaiHelperSimplified` as PTF base class to replace workaround use of `ThriftInterfaceDataPlane` base class.