### PR TITLE
Fix warning: wrong conversion from pointer to value

### DIFF
--- a/dash-pipeline/SAI/templates/saiapi.cpp.j2
+++ b/dash-pipeline/SAI/templates/saiapi.cpp.j2
@@ -193,7 +193,7 @@ sai_status_t sai_create_{{ table.name }}(
     return 0;
 ErrRet:
     delete matchActionEntry;
-    RemoveFromTable({{ table.name }}_id);
+    RemoveFromTable(*{{ table.name }}_id);
     return -1;
 }
 


### PR DESCRIPTION
Get the following warning due to a wrong conversion from pointer to value
```
saidashacl.cpp: In function 'sai_status_t sai_create_dash_acl_group(sai_object_id_t*, sai_object_id_t, uint32_t, const sai_attribute_t*)': saidashacl.cpp:96:21: warning: invalid conversion from 'sai_object_id_t*' {aka 'long unsigned int*'} to 'sai_object_id_t' {aka 'long unsigned int'} [-fpermissive]
     RemoveFromTable(dash_acl_group_id);
                     ^~~~~~~~~~~~~~~~~
In file included from saidashacl.cpp:9:
utils.h:227:38: note:   initializing argument 1 of 'bool RemoveFromTable(sai_object_id_t)'
 bool RemoveFromTable(sai_object_id_t id);
                      ~~~~~~~~~~~~~~~~^~
saidashacl.cpp: In function 'sai_status_t sai_create_dash_acl_rule(sai_object_id_t*, sai_object_id_t, uint32_t, const sai_attribute_t*)':
saidashacl.cpp:828:21: warning: invalid conversion from 'sai_object_id_t*' {aka 'long unsigned int*'} to 'sai_object_id_t' {aka 'long unsigned int'} [-fpermissive]
     RemoveFromTable(dash_acl_rule_id);
                     ^~~~~~~~~~~~~~~~
In file included from saidashacl.cpp:9:
utils.h:227:38: note:   initializing argument 1 of 'bool RemoveFromTable(sai_object_id_t)'
 bool RemoveFromTable(sai_object_id_t id);
                      ~~~~~~~~~~~~~~~~^~
saidasheni.cpp: In function 'sai_status_t sai_create_eni(sai_object_id_t*, sai_object_id_t, uint32_t, const sai_attribute_t*)':
saidasheni.cpp:376:21: warning: invalid conversion from 'sai_object_id_t*' {aka 'long unsigned int*'} to 'sai_object_id_t' {aka 'long unsigned int'} [-fpermissive]
     RemoveFromTable(eni_id);
                     ^~~~~~
In file included from saidasheni.cpp:9:
utils.h:227:38: note:   initializing argument 1 of 'bool RemoveFromTable(sai_object_id_t)'
 bool RemoveFromTable(sai_object_id_t id);
                      ~~~~~~~~~~~~~~~~^~
saidashvnet.cpp: In function 'sai_status_t sai_create_vnet(sai_object_id_t*, sai_object_id_t, uint32_t, const sai_attribute_t*)':
saidashvnet.cpp:96:21: warning: invalid conversion from 'sai_object_id_t*' {aka 'long unsigned int*'} to 'sai_object_id_t' {aka 'long unsigned int'} [-fpermissive]
     RemoveFromTable(vnet_id);
                     ^~~~~~~
In file included from saidashvnet.cpp:9:
utils.h:227:38: note:   initializing argument 1 of 'bool RemoveFromTable(sai_object_id_t)'
 bool RemoveFromTable(sai_object_id_t id);
                      ~~~~~~~~~~~~~~~~^~
```
Signed-off-by: Ze Gan <ganze718@gmail.com>